### PR TITLE
changes made to fix build issues for rocm

### DIFF
--- a/packages/atmi/package.py
+++ b/packages/atmi/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Atmi(CMakePackage):
+    """Asynchronous Task and Memory Interface, or ATMI, is a runtime framework and programming model for heterogeneous CPU-GPU systems. It provides a consistent, declarative API to create task graphs on CPUs and GPUs (integrated and discrete)."""
+       
+    homepage = "https://github.com/RadeonOpenCompute/atmi"
+    url      = "https://github.com/RadeonOpenCompute/atmi/archive/rocm-3.5.0.tar.gz"
+    
+    maintainers = ['Advanced Micro Devices Inc']
+
+    version('3.5.0', sha256='3fb57d2e583fab82bd0582d0c2bccff059ca91122c18ac49a7770a8bb041a37b')
+
+    variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('comgr@3.5:', type='build', when='@3.5:')
+    depends_on('hsa-rocr-dev@3.5:', type='build',when='@3.5:')
+    depends_on('libelf@0.8:', type='build',when='@3.5:')
+    root_cmakelists_dir = 'src'
+
+    def cmake_args(self):
+        # workaround as it was checking for /opt/rocm/.info/version in the make file
+        spec=self.spec
+        args = [
+                '-DROCM_VERSION=3.5.0-2588',
+                '-DCMAKE_VERBOSE_MAKEFILE=1',
+                '-DCMAKE_PREFIX_PATH={}/include/hsa;{}/hsa/lib;{}/include;{}/lib;{}/include;{}/lib'.format(spec['hsa-rocr-dev'].prefix, spec['hsa-rocr-dev'].prefix, spec['hsakmt-roct'].prefix, spec['hsakmt-roct'].prefix, spec['libelf'].prefix, spec['libelf'].prefix)
+               ]
+        return args
+
+    @run_after('install')
+    def install_stub(self):
+        install('include/atmi_interop_hsa.h', self.prefix.include)
+

--- a/packages/hip/package.py
+++ b/packages/hip/package.py
@@ -1,0 +1,32 @@
+from spack import *
+
+
+class Hip(CMakePackage):
+    """HIP is a C++ Runtime API and Kernel Language that allows developers to create portable applications for AMD and NVIDIA GPUs from single source code."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/HIP"
+    url      = "https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='ae8384362986b392288181bcfbe5e3a0ec91af4320c189bd83c844ed384161b3')
+
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('rocclr@3.5.0:',  when='@3.5.0:')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0')
+
+
+    def setup_build_environment(self, build_env):
+        build_env.unset('PERL5LIB')
+
+    def cmake_args(self):
+        args = ['-DHIP_COMPILER=clang',
+                '-DHIP_PLATFORM=rocclr',
+                '-DHSA_PATH={}'.format(self.spec['hsa-rocr-dev'].prefix),
+                '-DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE',
+                '-DCMAKE_SKIP_BUILD_RPATH=TRUE',
+                '-DLIBROCclr_STATIC_DIR={}/../rocclr_build'.format(self.stage.path)
+                ]
+        return args

--- a/packages/rocclr/package.py
+++ b/packages/rocclr/package.py
@@ -1,0 +1,39 @@
+
+from spack import *
+import os
+import shutil
+
+class Rocclr(CMakePackage):
+    """ROCclr is a virtual device interface that compute runtimes interact with to different backends such as ROCr or PAL This abstraction allows runtimes to work on Windows as well as on Linux without much effort."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCclr"
+    url      = "https://github.com/ROCm-Developer-Tools/ROCclr/archive/roc-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='87c1ee9f02b8aa487b628c543f058198767c474cec3d21700596a73c028959e1')
+
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='build', when='@3.5:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5:')
+    depends_on('mesa~llvm@18.3:', type='link', when='@3.5:')
+
+    resource(name='opencl-on-vdi',
+             url='https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.5.0.tar.gz',
+             sha256='511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0',
+             expand=True,
+             destination='',
+             placement='opencl-on-vdi')
+    build_directory = '../../rocclr_build'
+
+    @run_before('cmake')
+    def buildcleanup(self):
+        build_path=os.path.join(self.stage.path, '../rocclr_build')
+        shutil.rmtree(build_path, ignore_errors=True)
+
+    def cmake_args(self):
+        args = ['-DUSE_COMGR_LIBRARY=yes',
+                '-DOPENCL_DIR={}/opencl-on-vdi'.format(self.stage.source_path)]
+        return args
+

--- a/packages/rocgdb/package.py
+++ b/packages/rocgdb/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Rocgdb(AutotoolsPackage):
+    """This is ROCgdb, the ROCm source-level debugger for Linux, based on GDB, the GNU source-level debugger."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCgdb/"
+    url      = "https://github.com/ROCm-Developer-Tools/ROCgdb/archive/rocm-3.5.0.tar.gz"
+
+    maintainers = ['Advanced Micro Devices Inc']
+
+    version('3.5.0', sha256='cf36d956e84c7a5711b71f281a44b0a9708e13e941d8fca0247d01567e7ee7d1')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('texinfo')
+    depends_on('bison')
+    depends_on('flex')
+    depends_on('libunwind')
+    depends_on('expat')
+    depends_on('python')
+    depends_on('rocm-dbgapi@3.5:', type='link', when='@3.5:')
+    depends_on('comgr@3.5:', type='link', when='@3.5:')
+    build_directory = 'spack-build'
+ 
+    def configure_args(self):
+        spec = self.spec
+
+        # Generic options to compile GCC
+        options = [
+            # Distributor options
+            '--program-prefix=roc',
+            '--enable-64-bit-bfd',
+            '--with-bugurl=https://github.com/ROCm-Developer-Tools/ROCgdb/issues',
+            '--with-pkgversion=-ROCm',
+            '--enable-targets=x86_64-linux-gnu,amdgcn-amd-amdhsa',
+            '--disable-ld',
+            '--disable-gas',
+            '--disable-gdbserver',
+            '--disable-sim',
+            '--enable-tui',  
+            '--disable-gdbtk',
+            '--disable-shared',
+            '--with-expat',
+            '--with-system-zlib'
+            '--without-guile',
+            '--with-babeltrace',
+            '--with-lzma',
+            '--with-python'
+        ]
+        return options

--- a/packages/rocm-dbgapi/package.py
+++ b/packages/rocm-dbgapi/package.py
@@ -1,0 +1,26 @@
+from spack import *
+
+
+class RocmDbgapi(CMakePackage):
+    """The AMD Debugger API is a library that provides all the support necessary for a debugger and other tools to perform low level control of the execution and inspection of execution state of AMD's commercially available GPU architectures."""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCdbgapi"
+    url      = "https://github.com/ROCm-Developer-Tools/ROCdbgapi/archive/rocm-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='eeba0592bc79b90e5b874bba18fd003eab347e8a3cc80343708f8d19e047e87b')
+
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hsa-rocr-dev@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0')
+
+    def patch(self):
+        filter_file(r'(<INSTALL_INTERFACE:include>)',  r'\1 {}/include'.format(self.spec['hsa-rocr-dev'].prefix), 'CMakeLists.txt')
+
+    def cmake_args(self):
+        args = [
+                '-DCMAKE_VERBOSE_MAKEFILE=1',
+                '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
+               ]
+        return args

--- a/packages/rocm-debug-agent/package.py
+++ b/packages/rocm-debug-agent/package.py
@@ -1,0 +1,29 @@
+from spack import *
+
+class RocmDebugAgent(CMakePackage):
+    """Radeon Open Compute (ROCm) debug agent"""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/rocr_debug_agent"
+    url      = "https://github.com/ROCm-Developer-Tools/rocr_debug_agent/archive/roc-3.5.0.tar.gz"
+
+    maintainers = ['Advanced Micro Devices Inc.']
+
+    version('3.5.0', sha256='203ccb18d2ac508aae40bf364923f67375a08798b20057e574a0c5be8039f133')
+    
+    variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
+
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hsa-rocr-dev@3.5:', type='build', when='@3.5:')
+    depends_on('hsakmt-roct@3.5:', type='build', when='@3.5:')
+    depends_on("elfutils", type='link', when='@3.5:')
+    root_cmakelists_dir= 'src'
+
+    def cmake_args(self):
+        spec=self.spec
+        args = [
+                '-DCMAKE_VERBOSE_MAKEFILE=1',
+                '-DROCM_DIR={}'.format(spec['hsa-rocr-dev'].prefix),
+                '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
+                '-DCMAKE_PREFIX_PATH={}/include/hsa;{}/hsa/lib;{}/include;{}/lib,'.format(spec['hsa-rocr-dev'].prefix, spec['hsa-rocr-dev'].prefix, spec['hsakmt-roct'].prefix, spec['hsakmt-roct'].prefix)
+               ]
+        return args

--- a/packages/rocm-opencl/package.py
+++ b/packages/rocm-opencl/package.py
@@ -1,0 +1,32 @@
+from spack import *
+
+
+class RocmOpencl(CMakePackage):
+    """OpenCL: Open Computing Language on ROCclr"""
+
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
+    url      = "https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('rocclr@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('mesa~llvm@18.3:', type='link', when='@3.5:')
+
+    resource(name='rocclr',
+             url='https://github.com/ROCm-Developer-Tools/ROCclr/archive/roc-3.5.0.tar.gz',
+             sha256='87c1ee9f02b8aa487b628c543f058198767c474cec3d21700596a73c028959e1',
+             expand=True,
+             destination='',
+             placement='rocclr-src')
+
+    def cmake_args(self):
+        args = ['-DLIBROCclr_STATIC_DIR={}/../rocclr_build'.format(self.stage.path),
+                '-DUSE_COMGR_LIBRARY=yes',
+                '-DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE',
+                '-DCMAKE_SKIP_BUILD_RPATH=TRUE',
+                '-DROCclr_DIR={}/rocclr-src'.format(self.stage.source_path)
+               ]
+        return args

--- a/packages/rocm-smi-lib/package.py
+++ b/packages/rocm-smi-lib/package.py
@@ -1,0 +1,28 @@
+from spack import *
+from os import popen
+
+class RocmSmiLib(CMakePackage):
+    """It is a C library for Linux that provides a user space interface for applications to monitor and control GPU applications."""
+
+    homepage = "https://github.com/RadeonOpenCompute/rocm_smi_lib"
+    url      = "https://github.com/RadeonOpenCompute/rocm_smi_lib/archive/rocm-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='a5d2ec3570d018b60524f0e589c4917f03d26578443f94bde27a170c7bb21e6e')
+
+    variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
+    depends_on('cmake@3.5.2', type='build')
+
+    def cmake_args(self):
+        args=[
+              '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH="FALSE"',
+              '-DCMAKE_VERBOSE_MAKEFILE=1'
+             ]
+        return args
+
+    @run_after('install')
+    def post_install(self):
+        popen('cp -R {}/rocm_smi/lib {}'.format(self.prefix, self.prefix))
+        popen('cp -R {}/rocm_smi/include {}'.format(self.prefix, self.prefix))
+        popen('rm -R {}/rocm_smi'.format(self.prefix))

--- a/packages/rocprofiler-dev/package.py
+++ b/packages/rocprofiler-dev/package.py
@@ -1,0 +1,33 @@
+from spack import *
+
+
+class RocprofilerDev(CMakePackage):
+    """ROCPROFILER library for AMD HSA runtime API extension support"""
+
+    homepage = "https://github.com/ROCm-Developer-Tools/rocprofiler"
+    url      = "https://github.com/ROCm-Developer-Tools/rocprofiler/archive/rocm-3.5.0.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('3.5.0', sha256='c42548dd467b7138be94ad68c715254eb56a9d3b670ccf993c43cd4d43659937')
+
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocminfo@3.5.0:', type='build', when='@3.5.0:')
+
+    resource(name='roctracer-dev',
+             url='https://github.com/ROCm-Developer-Tools/roctracer/archive/rocm-3.5.0.tar.gz',
+             sha256='7af5326c9ca695642b4265232ec12864a61fd6b6056aa7c4ecd9e19c817f209e',
+             expand=True,
+             destination='',
+             placement='roctracer')
+
+    def patch(self):
+        filter_file('${HSA_RUNTIME_LIB_PATH}/../include', '${HSA_RUNTIME_LIB_PATH}/../include ${HSA_KMT_LIB_PATH}/../include', 'test/CMakeLists.txt', string=True)
+
+    def cmake_args(self):
+        args = ['-DPROF_API_HEADER_PATH={}/roctracer/inc/ext'.format(self.stage.source_path),
+                '-DROCM_ROOT_DIR:STRING={}/include'.format(self.spec['hsakmt-roct'].prefix)
+               ]
+        return args


### PR DESCRIPTION
Tested the rocm-debug agent for rocm3.5. Compared the rocm-debug-agent3.5.0-1.0.0.30500-rocm-rel-3.5-30-Linux with the spack generated and found to be same. hence pushing it to the rocm-spack