### PR TITLE
new recipes for rocblas,hipblas,rocsolver

### DIFF
--- a/packages/hipblas/package.py
+++ b/packages/hipblas/package.py
@@ -5,7 +5,8 @@
 
 
 from spack import *
-
+import os
+import re
 
 class Hipblas(CMakePackage):
     """hipBLAS is a BLAS marshalling library, with multiple supported backends. It sits between the application and a 'worker' BLAS library, marshalling inputs into the backend library and marshalling results back to the application. hipBLAS exports an interface that does not require the client to change, regardless of the chosen backend. Currently, hipBLAS supports rocBLAS and cuBLAS as backends."""
@@ -41,13 +42,21 @@ class Hipblas(CMakePackage):
 
     def cmake_args(self):
         spec=self.spec
+        # Finding the version of clang
+        hipcc = Executable(join_path(self.spec['hip'].prefix.bin, 'hipcc'))
+        version = hipcc('--version', output=str)
+        print(version)
+        version_group = re.search(r"clang version (\S+)", version)
+        print(version_group)
+        version_number = version_group.group(1)
+        print(version_number)
         args = [
                 '-DHIP_COMPILER=clang',
                 '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
                 '-DUSE_HIP_CLANG=ON',
                 '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
                 '-DCMAKE_PREFIX_PATH={};{}'.format(self.spec['comgr'].prefix,self.spec['llvm-amdgpu'].prefix),
-                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/{}/include'.format(self.spec['llvm-amdgpu'].prefix, version_number)
                ]
 
         return args

--- a/packages/hipblas/package.py
+++ b/packages/hipblas/package.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Hipblas(CMakePackage):
+    """hipBLAS is a BLAS marshalling library, with multiple supported backends. It sits between the application and a 'worker' BLAS library, marshalling inputs into the backend library and marshalling results back to the application. hipBLAS exports an interface that does not require the client to change, regardless of the chosen backend. Currently, hipBLAS supports rocBLAS and cuBLAS as backends."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipBLAS"
+    url      = "https://github.com/ROCmSoftwarePlatform/hipBLAS/archive/rocm-3.5.0.tar.gz"
+
+    maintainers = ['srekolam', 'arjun-raj-kuppala']
+
+    version('3.5.0', sha256='d451da80beb048767da71a090afceed2e111d01b3e95a7044deada5054d6e7b1')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hip@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocm-device-libs@3.5:', type='build', when='@3.5:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('rocclr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='link', when='@3.5.0:')
+    depends_on('rocminfo@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocblas@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocsolver@3.5.0:', type='build', when='@3.5.0:')
+
+    def setup_build_environment(self, build_env):
+        build_env.unset('PERL5LIB')
+        build_env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        build_env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+
+
+    def setup_run_environment(self, env):
+        env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        env.set('ROCM_PATH', self.spec['rocminfo'].prefix)
+        env.set('HIP_COMPILER', 'clang')
+        env.set('HIP_PLATFORM', 'hip-clang')
+
+    def cmake_args(self):
+        spec=self.spec
+        args = [
+                '-DHIP_COMPILER=clang',
+                '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
+                '-DUSE_HIP_CLANG=ON',
+                '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
+                '-DCMAKE_PREFIX_PATH={};{}'.format(self.spec['comgr'].prefix,self.spec['llvm-amdgpu'].prefix),
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+               ]
+
+        return args
+

--- a/packages/rocblas/package.py
+++ b/packages/rocblas/package.py
@@ -1,0 +1,77 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+import os
+import shutil
+
+
+class Rocblas(CMakePackage):
+    """rocBLAS is AMD's library for BLAS on ROCm. It is implemented in the HIP programming language and optimized 
+    for AMD's GPUs."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocBLAS"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocBLAS/archive/rocm-3.5.0.tar.gz"
+
+    maintainers = ['srekolam', 'arjun-raj-kuppala']
+
+    version('3.5.0', sha256='8560fabef7f13e8d67da997de2295399f6ec595edfd77e452978c140d5f936f0')
+    variant('build_type', default='Release', description='CMake build type')
+   
+    resource(name='Tensile',
+             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
+             commit='f842a1a4427624eff6cbddb2405c36dec9a210cd',
+             expand=True,
+             destination='',
+             placement='')
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-virtualenv', type='test')
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-pip', type=('build', 'run'))
+    depends_on('googletest', type='test')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hip@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocm-device-libs@3.5:', type='build', when='@3.5:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('rocclr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='link', when='@3.5.0:')
+    depends_on('rocminfo@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('lapack')
+    depends_on('boost')
+    depends_on('zlib', type= 'build', when='@3.5.0:')
+
+    def setup_build_environment(self, build_env):
+        build_env.unset('PERL5LIB')
+        build_env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        build_env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+        build_env.set('ROCM_AGENT_ENUM', self.spec['rocminfo'].prefix)
+        build_env.set('ROCM_PATH', self.spec['rocminfo'].prefix)
+        build_env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+
+
+    def setup_run_environment(self, env):
+        env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        env.set('ROCM_PATH', self.spec['rocminfo'].prefix)
+        env.set('HIP_COMPILER', 'clang')
+        env.set('HIP_PLATFORM', 'hip-clang')
+
+    def cmake_args(self):
+        spec=self.spec
+        args = [
+                '-DHIP_COMPILER=clang',
+                '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
+                '-DUSE_HIP_CLANG=ON',
+		'-DTensile_COMPILER=hipcc',
+		'-DTensile_CODE_OBJECT_VERSION=V3',
+                '-DRUN_HEADER_TESTING=OFF',
+                '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
+                '-DCMAKE_PREFIX_PATH=/usr/lib64/llvm7.0;{}'.format(self.spec['llvm-amdgpu'].prefix),
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+               ]
+        return args

--- a/packages/rocblas/package.py
+++ b/packages/rocblas/package.py
@@ -6,7 +6,7 @@
 
 from spack import *
 import os
-import shutil
+import re
 
 
 class Rocblas(CMakePackage):
@@ -63,6 +63,12 @@ class Rocblas(CMakePackage):
 
     def cmake_args(self):
         spec=self.spec
+        # Finding the version of clang
+        hipcc = Executable(join_path(self.spec['hip'].prefix.bin, 'hipcc'))
+        version = hipcc('--version', output=str)
+        version_group = re.search(r"clang version (\S+)", version)
+        version_number = version_group.group(1)
+
         args = [
                 '-DHIP_COMPILER=clang',
                 '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
@@ -72,6 +78,6 @@ class Rocblas(CMakePackage):
                 '-DRUN_HEADER_TESTING=OFF',
                 '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
                 '-DCMAKE_PREFIX_PATH=/usr/lib64/llvm7.0;{}'.format(self.spec['llvm-amdgpu'].prefix),
-                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/{}/include'.format(self.spec['llvm-amdgpu'].prefix, version_number)
                ]
         return args

--- a/packages/rocsolver/package.py
+++ b/packages/rocsolver/package.py
@@ -1,0 +1,53 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Rocsolver(CMakePackage):
+    """rocSOLVER is a work-in-progress implementation of a subset of LAPACK functionality on the ROCm platform."""
+
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocSOLVER"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocSOLVER/archive/3.5.0.tar.gz"
+
+    maintainers = ['srekolam', 'arjun-raj-kuppala']
+
+    version('3.6beta', sha256='a3cc6498e3afdf109da18e8b0a799b62ee1877567092ae4795307cad9f6632d3')
+    depends_on('cmake@3.5.2', type='build')
+    depends_on('hip@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocm-device-libs@3.5:', type='build', when='@3.5:')
+    depends_on('comgr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('rocclr@3.5.0:', type='build', when='@3.5.0')
+    depends_on('hsakmt-roct@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('hsa-rocr-dev@3.5.0:', type='link', when='@3.5.0:')
+    depends_on('rocminfo@3.5.0:', type='build', when='@3.5.0:')
+    depends_on('rocblas@3.5.0:', type='build', when='@3.5.0:')
+
+    def setup_build_environment(self, build_env):
+        build_env.unset('PERL5LIB')
+        build_env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        build_env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+
+
+    def setup_run_environment(self, env):
+        env.set('HIP_CLANG_PATH', self.spec['llvm-amdgpu'].prefix.bin)
+        env.set('ROCM_PATH', self.spec['rocminfo'].prefix)
+        env.set('HIP_COMPILER', 'clang')
+        env.set('HIP_PLATFORM', 'hip-clang')
+        #env.set('DEVICE_LIB_PATH', self.spec['rocm-device-libs'].prefix.lib)
+
+    def cmake_args(self):
+        spec=self.spec
+        args = [
+                '-DHIP_COMPILER=clang',
+                '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
+                '-DUSE_HIP_CLANG=ON',
+                '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
+                '-DCMAKE_PREFIX_PATH={};{}'.format(self.spec['comgr'].prefix,self.spec['llvm-amdgpu'].prefix),
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+               ]
+
+        return args

--- a/packages/rocsolver/package.py
+++ b/packages/rocsolver/package.py
@@ -5,7 +5,8 @@
 
 
 from spack import *
-
+import os
+import re
 
 class Rocsolver(CMakePackage):
     """rocSOLVER is a work-in-progress implementation of a subset of LAPACK functionality on the ROCm platform."""
@@ -41,13 +42,19 @@ class Rocsolver(CMakePackage):
 
     def cmake_args(self):
         spec=self.spec
+        # Finding the version of clang
+        hipcc = Executable(join_path(self.spec['hip'].prefix.bin, 'hipcc'))
+        version = hipcc('--version', output=str)
+        version_group = re.search(r"clang version (\S+)", version)
+        version_number = version_group.group(1)
+
         args = [
                 '-DHIP_COMPILER=clang',
                 '-DCMAKE_CXX_COMPILER={}/bin/hipcc'.format(self.spec['hip'].prefix),
                 '-DUSE_HIP_CLANG=ON',
                 '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE',
                 '-DCMAKE_PREFIX_PATH={};{}'.format(self.spec['comgr'].prefix,self.spec['llvm-amdgpu'].prefix),
-                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/11.0.0/include'.format(self.spec['llvm-amdgpu'].prefix)
+                '-DHIP_CLANG_INCLUDE_PATH={}/lib/clang/{}/include'.format(self.spec['llvm-amdgpu'].prefix, version_number)
                ]
 
         return args


### PR DESCRIPTION
Rocblas is currently dependent on the following. llvm-devel and llvm-static will install into /usr/lib64/llvm7.0 .
yum install llvm-toolset-7-llvm-devel
yum install llvm-toolset-7-llvm-static
yum install zlib-devel

Append the llvm-amdgpu prefix path to the PATH . This will compile the tensile kernels.
export PATH=$PATH:/spack/opt/spack/linux-centos7-zen/gcc-7.3.1/llvm-amdgpu-3.5.0-xxxxxxxxxxxxx 
add to CMAKE_PREFIX_PATH=/usr/lib64/llvm7.0